### PR TITLE
Staging

### DIFF
--- a/app/api/routes/google/auth.py
+++ b/app/api/routes/google/auth.py
@@ -78,9 +78,13 @@ async def oauth2callback(request: Request):
         if "session" in request.scope:
             request.session["google_credentials"] = credentials_to_dict(credentials)
 
-        return RedirectResponse(url=f"{FRONTEND_URL}/auth/success", status_code=302)
+        return RedirectResponse(
+            url=f"{FRONTEND_URL}/auth/success?platform=youtube", status_code=302
+        )
     except Exception as e:
-        return RedirectResponse(url=f"{FRONTEND_URL}?error={str(e)}")
+        return RedirectResponse(
+            url=f"{FRONTEND_URL}/auth/error?platform=youtube&{str(e)}"
+        )
 
 
 @router.get("/oauth/refresh")

--- a/app/api/routes/google/auth.py
+++ b/app/api/routes/google/auth.py
@@ -64,20 +64,23 @@ async def oauth2callback(request: Request):
     if url.startswith("http:"):
         url = "https:" + url[5:]
 
-    # Get the authorization response URL
-    authorization_response = str(url)
-    flow.fetch_token(authorization_response=authorization_response)
+    try:
+        # Get the authorization response URL
+        authorization_response = str(url)
+        flow.fetch_token(authorization_response=authorization_response)
 
-    # Store credentials in session
-    credentials = flow.credentials
-    if not credentials:
-        raise HTTPException(status_code=400, detail="No credentials found")
+        # Store credentials in session
+        credentials = flow.credentials
+        if not credentials:
+            raise HTTPException(status_code=400, detail="No credentials found")
 
-    # Store the credentials in the session
-    if "session" in request.scope:
-        request.session["google_credentials"] = credentials_to_dict(credentials)
+        # Store the credentials in the session
+        if "session" in request.scope:
+            request.session["google_credentials"] = credentials_to_dict(credentials)
 
-    return RedirectResponse(url=f"{FRONTEND_URL}/auth/success", status_code=302)
+        return RedirectResponse(url=f"{FRONTEND_URL}/auth/success", status_code=302)
+    except Exception as e:
+        return RedirectResponse(url=f"{FRONTEND_URL}?error={str(e)}")
 
 
 @router.get("/oauth/refresh")

--- a/app/api/routes/shared/public_auth.py
+++ b/app/api/routes/shared/public_auth.py
@@ -18,6 +18,8 @@ router = APIRouter()
 @router.get("/status", response_model=LoginStatusResponse)
 async def check_login_status(request: Request):
     """Check which platforms the user is logged into"""
+    # Kick login is not needed currently since there is no API support for features
+    # that require authentication. This is a placeholder for future use.
     try:
         platforms_status = [
             PlatformLoginStatus(
@@ -28,9 +30,7 @@ async def check_login_status(request: Request):
                 platform="Twitch",
                 loggedIn=bool(request.session.get("twitch_credentials")),
             ),
-            PlatformLoginStatus(
-                platform="Kick", loggedIn=bool(request.session.get("kick_credentials"))
-            ),
+            PlatformLoginStatus(platform="Kick", loggedIn=False),
         ]
 
         return LoginStatusResponse(data=platforms_status)

--- a/app/api/routes/twitch/auth.py
+++ b/app/api/routes/twitch/auth.py
@@ -112,10 +112,14 @@ async def twitch_callback(request: Request, code: str = "", error: str = ""):
             request.session["twitch_user_profile"] = user_profile
             request.session["twitch_credentials"] = token_data
 
-        return RedirectResponse(url=f"{FRONTEND_URL}/auth/success", status_code=302)
+        return RedirectResponse(
+            url=f"{FRONTEND_URL}/auth/success?platform=twitch", status_code=302
+        )
 
     except Exception as e:
-        return RedirectResponse(url=f"{FRONTEND_URL}?error={str(e)}")
+        return RedirectResponse(
+            url=f"{FRONTEND_URL}/auth/error?platform=twitch&{str(e)}"
+        )
 
 
 @router.get("/logout")


### PR DESCRIPTION
This pull request introduces updates to the OAuth callback handling for Google and Twitch authentication, along with adjustments to the login status check for supported platforms. The changes improve error handling, enhance platform-specific redirection, and simplify the handling of unsupported platforms like Kick.

### Improvements to OAuth Callbacks:

* **Google OAuth Callback**: Added a `try-except` block to handle exceptions during the OAuth flow. Updated the success redirection URL to include the platform (`youtube`) and added an error redirection URL with detailed error information. (`app/api/routes/google/auth.py`, [[1]](diffhunk://#diff-e071d3ab78068ffd0cb47cd5e9625347e3091b35d437068ba891d75f8019ffe4R67) [[2]](diffhunk://#diff-e071d3ab78068ffd0cb47cd5e9625347e3091b35d437068ba891d75f8019ffe4L80-R87)
* **Twitch OAuth Callback**: Updated the success redirection URL to include the platform (`twitch`) and modified the error redirection URL to include the platform and error details. (`app/api/routes/twitch/auth.py`, [app/api/routes/twitch/auth.pyL115-R122](diffhunk://#diff-3d9c41e34216858c6970652c411d3dfce981f73957a60008116c367c0e7a9d3dL115-R122))

### Simplifications to Login Status Check:

* **Kick Platform**: Replaced the dynamic check for Kick login status with a static `loggedIn=False` value, as Kick authentication is not currently supported. Added a placeholder comment for potential future use. (`app/api/routes/shared/public_auth.py`, [[1]](diffhunk://#diff-adfed33022950f7cac32c8fb4625fa82d7de2d50f716773376ac2c80aa2a27b2R21-R22) [[2]](diffhunk://#diff-adfed33022950f7cac32c8fb4625fa82d7de2d50f716773376ac2c80aa2a27b2L31-R33)